### PR TITLE
Handling set-cookie and removing some un-necessary code

### DIFF
--- a/src/HttpLibrary/__init__.py
+++ b/src/HttpLibrary/__init__.py
@@ -431,12 +431,14 @@ class HTTP(object):
         keyword is a list containing both values.
         """
         self.response_should_have_header(header_name)
-        result = []
-        if self.get_major_python_version() < 3:
-            result = self.response.headers.getall(header_name)
+
+        # if there are multiple headers with same name, we need to return as a list
+        if header_name == 'Set-Cookie': # Need to be specific, as we dont know any other headers like this
+            cookie_str = self.response.headers.getall(header_name)[0]
+            cookies_list = cookie_str.split('auth_tkt')
+            result = ['auth_tkt' + x.strip().rstrip(',') for x in cookies_list if x]
         else:
-            for header_val in self.response.headers.getall(header_name)[0].split(","):
-                result.append(header_val.strip())
+            result = self.response.headers.getall(header_name)
 
         return result
 

--- a/src/HttpLibrary/livetest.py
+++ b/src/HttpLibrary/livetest.py
@@ -159,16 +159,8 @@ class TestApp(webtest.TestApp):
                     response_headers.append((headername, headervalue))
         else:
             for headername in list(dict(webresp.getheaders()).keys()):
-                # this hack is to handle the set-cookie header which contains `,` in it.
-                # since python httplib concatenate header values with `,` separator, when there are multiple values
-                # for the same key
-                if headername == 'Set-Cookie':
-                    cookies_list = []
-                    for item in webresp.headers.get_all('Set-Cookie'):
-                        cookies_list.append(item.replace(',', ''))
-                    response_headers.append((headername, ', '.join(cookies_list)))
-                else:
-                    response_headers.append((headername, webresp.getheader(headername)))
+                response_headers.append((headername, webresp.getheader(headername)))
+
         res.headerlist = response_headers
         res.errors = ''
         return res


### PR DESCRIPTION
Currently, there is an issue when we have expiry time in the set-cookie and when http-library splits and joins it, it's breaking the semantics and hence these changes are required