### PR TITLE
Authorization header contents are properly decoded

### DIFF
--- a/src/HttpLibrary/__init__.py
+++ b/src/HttpLibrary/__init__.py
@@ -503,7 +503,7 @@ class HTTP(object):
         if isinstance(credentials, str):
             credentials = credentials.encode()
         self.set_request_header(
-            "Authorization", "Basic %s" % b64encode(credentials))
+            "Authorization", "Basic %s" % b64encode(credentials).decode('utf-8'))
 
     # payload
 


### PR DESCRIPTION
Basic authentication was broken because the result of `b64encode()` is binary. Decoding it with `decode('utf-8') fixes that.

Before: `Basic b'YWRtaW46YWRtaW4='`
Fixed: `Basic 'YWRtaW46YWRtaW4='`